### PR TITLE
Release Channels v0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -529,6 +529,11 @@ val lst = chInput.toList // List(1, 2, 3)
 ```
 
 ## Changelog
+- #### 0.2.0 released Feb 19, 2024.
+    - Add support for `default` block in `select()`.
+    - Add `after()` and `ticker()`.
+    - Change select() logic for synchronous channels to match behavior of GoLang.
+
 - #### 0.1.6 released Dec 3, 2023.
     - Fix channel filtering does not filter some values at random.
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.2.0"
+ThisBuild / version := "0.2.1-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.2.0-SNAPSHOT"
+ThisBuild / version := "0.2.0"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.1.7-SNAPSHOT"
+ThisBuild / version := "0.2.0-SNAPSHOT"


### PR DESCRIPTION
* #22 Implement select() logic for synchronous channels that match GoLang in https://github.com/yruslan/channel_scala/pull/26
* #23 Add support for `default` block in `select()`  in https://github.com/yruslan/channel_scala/pull/27
* #24 Add `after()` and `ticker()` in https://github.com/yruslan/channel_scala/pull/28